### PR TITLE
Remove compile warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule Zencoder.Mixfile do
     [
       app: :zencoder,
       version: "1.0.1",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       test_coverage: [tool: ExCoveralls],
-      deps: deps,
+      deps: deps(),
       package: [
         contributors: ["Adam Kittelson"],
         licenses: ["MIT"],


### PR DESCRIPTION
This warning pops up in all projects that use zencoder with newer Elixir versions.

There is a lot more that could be done by upgrading dependencies but I'm afraid that will break compatibility with older Elixir versions.